### PR TITLE
Users, tabs, and charts tables

### DIFF
--- a/migrations/20150814141029_add_charts.js
+++ b/migrations/20150814141029_add_charts.js
@@ -1,0 +1,35 @@
+exports.up = function(knex, Promise) {
+  return knex.schema.
+    createTable('users', function (table) {
+      table.increments('id').primary();
+      table.string('email').notNullable().unique(); // This should be adjusted to include lowercase attribute
+      table.string('password');
+      table.string('facebook');
+      table.string('twitter');
+      table.string('google');
+      table.string('github');
+      table.string('instagram');
+      table.string('tokens'); // This should be converted to an array
+      table.json('profile').nullable();
+      table.string('resetPasswordToken');
+      table.date('resetPasswordExpires').nullable();
+      table.timestamps();
+    }).
+    createTable('tabs', function (table) {
+      table.increments('id').primary();
+      table.integer('user_id').notNullable() // .references('id').inTable('users');
+      table.integer('tab_list_order').notNullable();   
+      table.string('tab_name');
+      table.timestamps();
+    }).
+    createTable('charts', function (table) {
+      table.increments('id').primary();
+      table.integer('tab_id').notNullable() // .references('id').inTable('tabs');
+      table.integer('chart_list_order').notNullable(); 
+      table.json('chart_params');
+      table.timestamps();
+    });
+};
+exports.down = function(knex, Promise) {
+  return knex.schema.dropTable('charts').dropTable('tabs').dropTable('users');
+};

--- a/seeds/seed_charts.js
+++ b/seeds/seed_charts.js
@@ -1,0 +1,33 @@
+
+exports.seed = function(knex, Promise) {
+  return Promise.join(
+    // Deletes ALL existing entries
+    knex('charts').del(),
+    knex('tabs').del(),
+    knex('users').del(),
+
+    // Inserts seed entries
+    knex('users').insert({email: 'brad@toomanybrads.com'}),
+    knex('users').insert({email: 'thebrad@brad.com'}),
+    knex('users').insert({email: 'bradley@bradcorp.com'}),
+    knex('tabs').insert({user_id: 1, tab_list_order: 1, tab_name: "Election 2015"}),
+    knex('tabs').insert({user_id: 1, tab_list_order: 2, tab_name: "Economy"}),
+    knex('tabs').insert({user_id: 1, tab_list_order: 3, tab_name: "BC issues"}),
+    knex('charts').insert({tab_id: 1, chart_list_order: 1, 
+      chart_params: { title: "Party Leaders", chart_type: "snapshot", 
+      keywords: ["Mulcair", "Trudeau", "Harper"], publishers: [1,2,3] }
+    }),
+    knex('charts').insert({tab_id: 1, chart_list_order: 2, 
+      chart_params: { title: "Security", chart_type: "snapshot", 
+      keywords: ["ISIS", "Terrorism", "RCMP"], publishers: [1,2,3] }
+    }),
+    knex('charts').insert({tab_id: 1, chart_list_order: 3, 
+      chart_params: { title: "Duffy Scandal", chart_type: "timelapse", 
+      keywords: ["Duffy", "Wright", "Senate"], publishers: [1,2,3] }
+    }),
+    knex('charts').insert({tab_id: 2, chart_list_order: 3, 
+      chart_params: { title: "Economy", chart_type: "timelapse", 
+      keywords: ["Taxes", "Economy", "Jobs"], publishers: [1,2,3] }
+    })
+  );
+};

--- a/seeds/seed_publishers.js
+++ b/seeds/seed_publishers.js
@@ -1,12 +1,12 @@
 
 exports.seed = function(knex, Promise) {
-  return Promise.join(
-    // Deletes ALL existing entries
-    knex('articles').del(),
-    knex('publishers').del(),
+  // return Promise.join(
+  //   // Deletes ALL existing entries
+  //   knex('articles').del(),
+  //   knex('publishers').del(),
 
-    // Inserts seed entries
-    knex('publishers').insert({id: 1, domain: 'http://theglobeandmail.com', name: 'The Globe and Mail', location: 'national', language: 'english'}),
-    knex('publishers').insert({id: 2, domain: 'http://nationalpost.com', name: 'National Post', location: 'national', language: 'english'})
-  );
+  //   // Inserts seed entries
+  //   knex('publishers').insert({id: 1, domain: 'http://theglobeandmail.com', name: 'The Globe and Mail', location: 'national', language: 'english'}),
+  //   knex('publishers').insert({id: 2, domain: 'http://nationalpost.com', name: 'National Post', location: 'national', language: 'english'})
+  // );
 };

--- a/seeds/seed_publishers.js
+++ b/seeds/seed_publishers.js
@@ -1,12 +1,12 @@
 
 exports.seed = function(knex, Promise) {
-  // return Promise.join(
-  //   // Deletes ALL existing entries
-  //   knex('articles').del(),
-  //   knex('publishers').del(),
+  return Promise.join(
+    // Deletes ALL existing entries
+    knex('articles').del(),
+    knex('publishers').del(),
 
-  //   // Inserts seed entries
-  //   knex('publishers').insert({id: 1, domain: 'http://theglobeandmail.com', name: 'The Globe and Mail', location: 'national', language: 'english'}),
-  //   knex('publishers').insert({id: 2, domain: 'http://nationalpost.com', name: 'National Post', location: 'national', language: 'english'})
-  // );
+    // Inserts seed entries
+    knex('publishers').insert({id: 1, domain: 'http://theglobeandmail.com', name: 'The Globe and Mail', location: 'national', language: 'english'}),
+    knex('publishers').insert({id: 2, domain: 'http://nationalpost.com', name: 'National Post', location: 'national', language: 'english'})
+  );
 };

--- a/server.js
+++ b/server.js
@@ -10,8 +10,10 @@ var app = express();
 var isProduction = process.env.NODE_ENV === 'production';
 var port = isProduction ? process.env.PORT : 3000;
 var publicPath = path.resolve(__dirname, 'public');
+
 var queryDetail = require('./sql_builder').queryDetail;
 var getPublisherList = require('./sql_builder').getPublisherList;
+var getCharts = require('./sql_builder').getCharts;
 
 app.use(express.static(publicPath));
 
@@ -30,12 +32,16 @@ app.get('/detail', function(req, res) {
 });
 
 app.get('/publishers', function(req, res) {
-
   getPublisherList(function(resp) {
     res.send(resp);
   });
+});
 
-})
+app.get('/users/:user/charts', function(req, res) {
+  getCharts(req.params.user, function(resp) {
+    res.send(resp);
+  });
+});
 
 if (!isProduction) {
 

--- a/sql_builder.js
+++ b/sql_builder.js
@@ -39,10 +39,14 @@ var getPublisherList = function(callback) {
   knex.select().from("publishers").then(callback)
 }
 
-var getTopKeywords = function(d, p, callback) {
-  // TODO: return top ten(?) keywords for a given set of publishers and date range
+var getCharts = function(user, callback) {
+  knex.select('charts.id', 'charts.chart_list_order', 'charts.chart_params', 'charts.tab_id', 'tabs.tab_list_order', 'tabs.tab_name')
+    .from("charts")
+    .leftJoin('tabs', 'charts.tab_id', 'tabs.id')
+    .where('tabs.user_id', user)
+    .then(callback);
 }
-
 
 exports.queryDetail = queryDetail;
 exports.getPublisherList = getPublisherList;
+exports.getCharts = getCharts;


### PR DESCRIPTION
A migration, seed file, and server route for accessing a user's saved chart parameters.

Thanks to @Araphel for the migrations. I had to comment out the code that set the foreign key relations. For some reason I couldn't seed tabs data with those references in place. 

WARNING: Don't run knex seed:run if you don't want to drop all of the articles from your articles table.
First, comment out the contents of the Promise.join in the seed_publishers.js file. 

To test:
knex migrate:latest
knex seed:run
http://localhost:3000/users/1/charts
