### PR TITLE
Scraper bug fix and freeze - see message for instructions

### DIFF
--- a/scrapers/scrapefeedly.rb
+++ b/scrapers/scrapefeedly.rb
@@ -19,35 +19,44 @@ require './scraper'
 # newerThan
 # Optional long timestamp in ms.
 #
-# For reference, the election was called on Sunday, August 8, 2015.
+# For reference, the election was called on Sunday, August 2, 2015.
 # 12:00:01AM EDT on that date corresponds to an epoch time of 1438488001.
 #
 # To scrape articles since that date,
 # set query parameters to "&newerThan=1438488001&count=10000"
 
 
-query_parameters = "&newerThan=1438488001&count=100000"
+query_parameters = "&newerThan=1438488001&count=10000"
 
 globeandmail = open("http://feedly.com/v3/streams/contents?streamId=feed/http://www.theglobeandmail.com/news/politics/?service=rss#{query_parameters}").read
 nationalpost = open("http://feedly.com/v3/streams/contents?streamId=feed/http://news.nationalpost.com/category/news/canada/canadian-politics/feed/#{query_parameters}").read
 cbc =          open("http://feedly.com/v3/streams/contents?streamId=feed/http://rss.cbc.ca/lineup/politics.xml#{query_parameters}").read
 vancouversun = open("http://feedly.com/v3/streams/contents?streamId=feed/http://rss.canada.com/get/?F7431#{query_parameters}").read
 torontostar = open("http://feedly.com/v3/streams/contents?streamId=feed/http://www.thestar.com/feeds.articles.news.canada.rss#{query_parameters}").read
-
+# huffingtonpost = open("http://feedly.com/v3/streams/contents?streamId=feed/http://www.huffingtonpost.com/feeds/verticals/canada-politics/index.xml#{query_parameters}").read
 
 puts "\n"
-puts "Scraping Globe and Mail"
+puts "Scraping Globe and Mail - Politics"
 parseArticles(globeandmail)
 puts "\n"
-puts "Scraping National Post"
+puts "Scraping National Post - Politics"
 parseArticles(nationalpost)
 puts "\n"
-puts "Scraping CBC"
+puts "Scraping CBC - Politics"
 parseArticles(cbc)
 puts "\n"
-puts "Scraping Vancouver Sun"
+puts "Scraping Vancouver Sun - Politics"
 parseArticles(vancouversun)
 puts "\n"
-puts "Scraping Toronto Star"
+puts "Scraping Toronto Star - Politics"
 parseArticles(torontostar)
+
+## Huffington post is not activated because there are issues with parsing the articles.
+## The Readabilty gem grabs a bunch of content outside of the main article content.
+## It will take a little bit of debugging to get it to work.
+
+# puts "\n"
+# puts "Scraping Huffington Post - Politics"
+# parseArticles(huffingtonpost)
+
 puts "\n** Scraping complete **\n "


### PR DESCRIPTION
@mattfoulger @jzhang729 @Araphel 

1) Default scraping parameters are now set to the most recent 10,000 articles per feed published after 00:00:01 EDT on Sunday, August 2, 2015, corresponding with the call of the 2015 Canadian federal election. Everyone should roll back their databases, migrate to the latest schema, and run this scrape today to put all of our development databases in a near-equal state.

2) The scraping algorithm now includes a date verification step prior to inserting an article in the database. The feedly feeds were apparently including articles outside of the date specified in the feed url parameters, leading to database entries for articles published prior to the election call. This issue is now resolved.

3) A Huffington Post scraper has been added in beta form (currently commented out and inactive). Unfortunately the Readability gem brings back more content than just the article itself when used on HuffPost's pages. This will take some debugging to resolve.